### PR TITLE
feat(web-app): setup tests with vitest and testing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ yarn build
 
 Builds the app for production to the dist folder.
 
+### Run tests
+
+```shell
+yarn test
+```
+
+Runs the test suite once with [Vitest](https://vitest.dev). Use `yarn test:watch` for watch mode or `yarn test:coverage` for a coverage report.
+
 ## Environment Variables
 
 | #   | Name                      | Type      | Description            | Default |

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "format:write": "prettier --write .",
     "lint:check": "eslint src/**/*.{js,jsx}",
     "lint:fix": "eslint --fix .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "prepare": "husky",
     "commit": "cz"
   },
@@ -88,7 +91,9 @@
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",
     "@eslint/js": "^10.0.1",
+    "@testing-library/dom": "^10.4.1",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.8",
     "cz-conventional-changelog": "3.3.0",
     "esbuild": "0.28.0",
     "eslint": "^10.2.0",
@@ -99,11 +104,13 @@
     "eslint-plugin-react-hooks": "^7.0.0",
     "globals": "^17.0.0",
     "husky": "^9.1.7",
+    "jsdom": "^29.1.1",
     "lint-staged": "^16.2.4",
     "prop-types": "^15.8.1",
     "sass": "^1.93.2",
     "vite": "8.0.7",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "vitest": "^4.1.8"
   },
   "lint-staged": {
     "*.{jsx,js}": "yarn lint:check",

--- a/src/components/Loader/index.test.jsx
+++ b/src/components/Loader/index.test.jsx
@@ -1,0 +1,20 @@
+/**
+ * Module dependencies.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Loader from './index';
+import React from 'react';
+
+/**
+ * Tests for the `Loader` component.
+ */
+
+describe('Loader', () => {
+  it('renders the loader element', () => {
+    const { container } = render(<Loader />);
+
+    expect(container.querySelector('.loader')).toBeInTheDocument();
+  });
+});

--- a/src/services/store/favorites/favoritesReducer.test.js
+++ b/src/services/store/favorites/favoritesReducer.test.js
@@ -1,0 +1,44 @@
+/**
+ * Module dependencies.
+ */
+
+import { addFavorite, favorites, removeFavorite } from './favoritesReducer';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Tests for the `favorites` reducer.
+ */
+
+describe('favorites reducer', () => {
+  const item = { key: 'catalog.product-1', name: 'Product 1' };
+
+  it('adds a favorite and persists it to local storage', () => {
+    const state = favorites([], addFavorite(item));
+
+    expect(state).toEqual([item]);
+    expect(JSON.parse(localStorage.getItem('favorites'))).toEqual([item]);
+  });
+
+  it('does not add a duplicate favorite', () => {
+    const state = favorites([item], addFavorite({ ...item }));
+
+    expect(state).toEqual([item]);
+  });
+
+  it('removes a favorite by key', () => {
+    const state = favorites([item], removeFavorite(item.key));
+
+    expect(state).toEqual([]);
+    expect(JSON.parse(localStorage.getItem('favorites'))).toEqual([]);
+  });
+
+  it('hydrates from local storage when the state is empty', () => {
+    localStorage.setItem('favorites', JSON.stringify([item]));
+
+    expect(favorites([], {})).toEqual([item]);
+  });
+
+  it('returns an empty array when local storage is empty', () => {
+    expect(favorites([], {})).toEqual([]);
+  });
+});

--- a/src/services/utils/index.test.js
+++ b/src/services/utils/index.test.js
@@ -1,0 +1,121 @@
+/**
+ * Module dependencies.
+ */
+
+import {
+  convertToFloat,
+  getAveragePrice,
+  getFormattedPrice,
+  getLastPrice,
+  renderCatalogName,
+  tryParsePrice
+} from './index';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Tests for `convertToFloat`.
+ */
+
+describe('convertToFloat', () => {
+  it('converts a comma-separated price string', () => {
+    expect(convertToFloat('1,99 €')).toBe('1.99');
+  });
+
+  it('converts a dot-separated price string', () => {
+    expect(convertToFloat('10.50')).toBe('10.50');
+  });
+
+  it('returns 0 for null, undefined or empty values', () => {
+    expect(convertToFloat(null)).toBe(0);
+    expect(convertToFloat(undefined)).toBe(0);
+    expect(convertToFloat('')).toBe(0);
+  });
+
+  it('returns 0 for unparseable values', () => {
+    expect(convertToFloat('abc')).toBe(0);
+  });
+});
+
+/**
+ * Tests for `tryParsePrice`.
+ */
+
+describe('tryParsePrice', () => {
+  it('parses a comma-separated price string to a number', () => {
+    expect(tryParsePrice('1,99 €')).toBe(1.99);
+  });
+
+  it('returns null for null, undefined or empty values', () => {
+    expect(tryParsePrice(null)).toBeNull();
+    expect(tryParsePrice(undefined)).toBeNull();
+    expect(tryParsePrice('')).toBeNull();
+  });
+
+  it('returns null for unparseable values', () => {
+    expect(tryParsePrice('abc')).toBeNull();
+  });
+});
+
+/**
+ * Tests for `getFormattedPrice`.
+ */
+
+describe('getFormattedPrice', () => {
+  it('prefers the campaign price when present', () => {
+    expect(getFormattedPrice({ campaignPrice: '2,50 €', regularPrice: '3,00 €' })).toBe('2.50');
+  });
+
+  it('falls back to the regular price', () => {
+    expect(getFormattedPrice({ regularPrice: '3,00 €' })).toBe('3.00');
+  });
+
+  it('returns 0 when no price is available', () => {
+    expect(getFormattedPrice({})).toBe(0);
+  });
+});
+
+/**
+ * Tests for `getLastPrice`.
+ */
+
+describe('getLastPrice', () => {
+  it('returns the formatted price of the last entry', () => {
+    const product = {
+      prices: [{ regularPrice: '1,00 €' }, { regularPrice: '2,00 €' }]
+    };
+
+    expect(getLastPrice(product)).toBe('2.00');
+  });
+
+  it('returns 0 when the product has no prices', () => {
+    expect(getLastPrice({ prices: [] })).toBe(0);
+  });
+});
+
+/**
+ * Tests for `getAveragePrice`.
+ */
+
+describe('getAveragePrice', () => {
+  it('returns the average rounded to two decimal places', () => {
+    const prices = [{ regularPrice: '1,00 €' }, { regularPrice: '2,00 €' }];
+
+    expect(getAveragePrice(prices)).toBe('1.50');
+  });
+});
+
+/**
+ * Tests for `renderCatalogName`.
+ */
+
+describe('renderCatalogName', () => {
+  it('returns the catalog name from the product data', () => {
+    expect(renderCatalogName({ catalog: 'catalog-id', data: { catalogName: 'My Catalog' } })).toBe(
+      'My Catalog'
+    );
+  });
+
+  it('falls back to the catalog identifier', () => {
+    expect(renderCatalogName({ catalog: 'catalog-id', data: {} })).toBe('catalog-id');
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,16 @@
-// Jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+/**
+ * Module dependencies.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+/**
+ * Cleanup the DOM and local storage after each test.
+ */
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -59,5 +59,14 @@ export default defineConfig({
     watch: {
       usePolling: true
     }
+  },
+  test: {
+    coverage: {
+      include: ['src/**/*.{js,jsx}'],
+      provider: 'v8',
+      reporter: ['text', 'lcov']
+    },
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.js']
   }
 });


### PR DESCRIPTION
## Description

Sets up a test infrastructure for the project, closing #16.

- **Vitest** as the test runner (native fit for the existing Vite build, reuses `vite.config.mjs`)
- **jsdom** environment + `@testing-library/jest-dom` matchers wired through `src/setupTests.js` (DOM and `localStorage` are reset between tests)
- `@testing-library/dom` added explicitly (peer of the already-present `@testing-library/react` v16)
- Scripts: `yarn test`, `yarn test:watch`, `yarn test:coverage` (v8 provider, text + lcov)
- README section on running tests

### Seed tests (21 passing)

- `src/services/utils/index.test.js` — price helpers (`convertToFloat`, `tryParsePrice`, `getFormattedPrice`, `getLastPrice`, `getAveragePrice`, `renderCatalogName`)
- `src/services/store/favorites/favoritesReducer.test.js` — add/dedupe/remove + localStorage hydration
- `src/components/Loader/index.test.jsx` — component smoke test proving the React/jsdom pipeline works

### Notes

- Tests use explicit `vitest` imports rather than globals, so no ESLint config changes were needed.
- A follow-up could add a GitHub Actions workflow running `yarn lint:check` + `yarn test` on PRs — happy to send that separately if wanted.